### PR TITLE
Added #failed delegate method to status class

### DIFF
--- a/lib/activejob-status/status.rb
+++ b/lib/activejob-status/status.rb
@@ -1,7 +1,7 @@
 module ActiveJob::Status
   class Status
     delegate :[], :to_s, :inspect, to: :read
-    delegate :queued?, :working?, :completed?, to: :status_inquiry
+    delegate :queued?, :working?, :completed?, :failed?, to: :status_inquiry
 
     def initialize(job)
       @job = job


### PR DESCRIPTION
This allows calling `status.failed?` just like we can do with the other statuses used by the gem.
