### PR TITLE
fix ActiveJob::Status.options when @@options is empty

### DIFF
--- a/lib/activejob-status.rb
+++ b/lib/activejob-status.rb
@@ -31,7 +31,7 @@ module ActiveJob::Status
     end
 
     def options
-      @@options || { expires_in: DEFAULT_EXPIRY }
+      @@options ||= { expires_in: DEFAULT_EXPIRY }
     end
 
     def store= store


### PR DESCRIPTION
Hi there,

I found an issue when using the `ActiveJob::Status` module with ruby 2.3.4, when the `@@options` class variable is empty.

During the `job.status.update(status: :queued)` hook It raises :

```
NameError - uninitialized class variable @@options in ActiveJob::Status
```

So I just changed the `#options` method to assign the `@@options` variable if it is not set, and it fixed the issue.