### PR TITLE
Implement job batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ end
 job       = MyJob.perform_later
 other_job = OtherJob.perform_later 
 
-batch = ActiveJob::Status::Batch.new(job, other_job)
+batch = ActiveJob::Status::Batch.new([job, other_job])
 batch.status
 # "queued"
 ```
@@ -356,7 +356,7 @@ class CallbacksJob < ApplicationJob
   queue_as :real_time
 
   def perform(*job_ids)
-    batch = ActiveJob::Status::Batch.new(*job_ids)
+    batch = ActiveJob::Status::Batch.new(job_ids)
 
     case batch.status
     when :queued, :working

--- a/README.md
+++ b/README.md
@@ -324,6 +324,24 @@ class MyJob < ActiveJob::Base
 end
 ```
 
+### Grouping jobs into batches
+
+```ruby
+job       = MyJob.perform_later
+other_job = OtherJob.perform_later 
+
+batch = ActiveJob::Status::Batch.new(job, other_job)
+batch.status
+# "queued"
+```
+
+The batch status can be `queued`, `failed`, `completed` or `working`.
+
+1. The batch is considered `queued` if **all** of the jobs are `queued`
+2. The batch is considered `failed` if **one** of the jobs is `failed`
+3. The batch is considered `completed` if **all** of the jobs are `completed`
+4. The batch is considered `working` in all other circumstances
+
 ## ActiveJob::Status and exceptions
 
 Internally, ActiveJob::Status uses `ActiveSupport#rescue_from` to catch every `Exception` to apply the `failed` status

--- a/lib/activejob-status.rb
+++ b/lib/activejob-status.rb
@@ -8,6 +8,7 @@ require "activejob-status/storage"
 require "activejob-status/status"
 require "activejob-status/progress"
 require "activejob-status/throttle"
+require "activejob-status/batch"
 
 module ActiveJob
   module Status

--- a/lib/activejob-status/batch.rb
+++ b/lib/activejob-status/batch.rb
@@ -3,7 +3,7 @@
 module ActiveJob
   module Status
     class Batch
-      def initialize(*jobs)
+      def initialize(jobs)
         @statuses = jobs.map { |job| ActiveJob::Status.get(job) }
       end
 

--- a/lib/activejob-status/batch.rb
+++ b/lib/activejob-status/batch.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Status
+    class Batch
+      def initialize(*jobs)
+        @statuses = jobs.map { |job| ActiveJob::Status.get(job) }
+      end
+
+      def status
+        if @statuses.all? { |status| status[:status] == :queued }
+          :queued
+        elsif @statuses.any? { |status| status[:status] == :failed }
+          :failed
+        elsif @statuses.all? { |status| status[:status] == :completed }
+          :completed
+        else
+          :working
+        end
+      end
+    end
+  end
+end

--- a/lib/activejob-status/batch.rb
+++ b/lib/activejob-status/batch.rb
@@ -4,19 +4,30 @@ module ActiveJob
   module Status
     class Batch
       def initialize(jobs)
-        @statuses = jobs.map { |job| ActiveJob::Status.get(job) }
+        @jobs = jobs
+        @storage = ActiveJob::Status::Storage.new
       end
 
       def status
-        if @statuses.all? { |status| status[:status] == :queued }
+        if @jobs.all? { |job| status_for(job) == :queued }
           :queued
-        elsif @statuses.any? { |status| status[:status] == :failed }
+        elsif @jobs.any? { |job| status_for(job) == :failed }
           :failed
-        elsif @statuses.all? { |status| status[:status] == :completed }
+        elsif @jobs.all? { |job| status_for(job) == :completed }
           :completed
         else
           :working
         end
+      end
+
+      private
+
+      def statuses
+        @statuses ||= @storage.read_multi(@jobs)
+      end
+
+      def status_for(job)
+        statuses.dig(@storage.key(job), :status)
       end
     end
   end

--- a/lib/activejob-status/batch.rb
+++ b/lib/activejob-status/batch.rb
@@ -9,26 +9,23 @@ module ActiveJob
       end
 
       def status
-        if @jobs.all? { |job| status_for(job) == :queued }
-          :queued
-        elsif @jobs.any? { |job| status_for(job) == :failed }
+        statuses = read.values.pluck(:status)
+
+        if statuses.include?(:failed)
           :failed
-        elsif @jobs.all? { |job| status_for(job) == :completed }
+        elsif statuses.all?(:queued)
+          :queued
+        elsif statuses.all?(:completed)
           :completed
         else
           :working
         end
       end
 
-      private
-
-      def statuses
-        @statuses ||= @storage.read_multi(@jobs)
+      def read
+        @storage.read_multi(@jobs)
       end
-
-      def status_for(job)
-        statuses.dig(@storage.key(job), :status)
-      end
+      alias_method :to_h, :read
     end
   end
 end

--- a/lib/activejob-status/storage.rb
+++ b/lib/activejob-status/storage.rb
@@ -26,6 +26,10 @@ module ActiveJob
         store.read(key(job)) || {}
       end
 
+      def read_multi(jobs)
+        store.read_multi(*jobs.map { |job| key(job) })
+      end
+
       def write(job, message, force: false)
         @throttle.wrap(force: force) do
           store.write(key(job), message, expires_in: @expires_in)

--- a/lib/activejob-status/storage.rb
+++ b/lib/activejob-status/storage.rb
@@ -27,7 +27,9 @@ module ActiveJob
       end
 
       def read_multi(jobs)
-        store.read_multi(*jobs.map { |job| key(job) })
+        keys = jobs.map { |job| key(job) }
+        data = store.read_multi(*keys)
+        keys.index_with { |k| data.fetch(k, {}) }
       end
 
       def write(job, message, force: false)

--- a/spec/specs/active_job/status/batch_spec.rb
+++ b/spec/specs/active_job/status/batch_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+require_relative "../../../jobs/test_jobs"
+
+RSpec.describe ActiveJob::Status::Batch do
+  describe "#status" do
+    it "returns queued when all jobs are queued" do
+      first_job = BaseJob.perform_later
+      second_job = BaseJob.perform_later
+      batch = described_class.new(first_job, second_job)
+
+      ActiveJob::Status.get(first_job).update(status: :queued)
+      ActiveJob::Status.get(second_job).update(status: :queued)
+
+      expect(batch.status).to eq(:queued)
+    end
+
+    it "returns failed when one job is failed" do
+      first_job = BaseJob.perform_later
+      second_job = BaseJob.perform_later
+      batch = described_class.new(first_job, second_job)
+
+      ActiveJob::Status.get(first_job).update(status: :failed)
+      ActiveJob::Status.get(second_job).update(status: :completed)
+
+      expect(batch.status).to eq(:failed)
+    end
+
+    it "returns completed when all jobs are completed" do
+      first_job = BaseJob.perform_later
+      second_job = BaseJob.perform_later
+      batch = described_class.new(first_job, second_job)
+
+      ActiveJob::Status.get(first_job).update(status: :completed)
+      ActiveJob::Status.get(second_job).update(status: :completed)
+
+      expect(batch.status).to eq(:completed)
+    end
+
+    it "returns working in other cases" do
+      first_job = BaseJob.perform_later
+      second_job = BaseJob.perform_later
+      batch = described_class.new(first_job, second_job)
+
+      ActiveJob::Status.get(first_job).update(status: :queued)
+      ActiveJob::Status.get(second_job).update(status: :working)
+
+      expect(batch.status).to eq(:working)
+    end
+  end
+end

--- a/spec/specs/active_job/status/batch_spec.rb
+++ b/spec/specs/active_job/status/batch_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ActiveJob::Status::Batch do
     it "returns queued when all jobs are queued" do
       first_job = BaseJob.perform_later
       second_job = BaseJob.perform_later
-      batch = described_class.new(first_job, second_job)
+      batch = described_class.new([first_job, second_job])
 
       ActiveJob::Status.get(first_job).update(status: :queued)
       ActiveJob::Status.get(second_job).update(status: :queued)
@@ -19,7 +19,7 @@ RSpec.describe ActiveJob::Status::Batch do
     it "returns failed when one job is failed" do
       first_job = BaseJob.perform_later
       second_job = BaseJob.perform_later
-      batch = described_class.new(first_job, second_job)
+      batch = described_class.new([first_job, second_job])
 
       ActiveJob::Status.get(first_job).update(status: :failed)
       ActiveJob::Status.get(second_job).update(status: :completed)
@@ -30,7 +30,7 @@ RSpec.describe ActiveJob::Status::Batch do
     it "returns completed when all jobs are completed" do
       first_job = BaseJob.perform_later
       second_job = BaseJob.perform_later
-      batch = described_class.new(first_job, second_job)
+      batch = described_class.new([first_job, second_job])
 
       ActiveJob::Status.get(first_job).update(status: :completed)
       ActiveJob::Status.get(second_job).update(status: :completed)
@@ -41,7 +41,7 @@ RSpec.describe ActiveJob::Status::Batch do
     it "returns working in other cases" do
       first_job = BaseJob.perform_later
       second_job = BaseJob.perform_later
-      batch = described_class.new(first_job, second_job)
+      batch = described_class.new([first_job, second_job])
 
       ActiveJob::Status.get(first_job).update(status: :queued)
       ActiveJob::Status.get(second_job).update(status: :working)


### PR DESCRIPTION
## Summary

Implements job batches. This is used to group multiple job and "calculate" a single status for the group of jobs.

This is useful when you want to schedule multiple batches of work for a single resource in parallel, but you want to know when all of them complete or if one fails.

It's a really simple implementation that doesn't add any additional complexity, just adds a way to calculate a single status for a group of statuses.

### Background

We're looking to switch from Sidekiq to SolidQueue, but we use Sidekiq batches. This gem provides a lot of the underlying mechanics, but not the actual batches. We'd love to be able to complement SolidQueue with this gem to achieve equivalent functionality we had in Sidekiq.