### PR TITLE
Remove ruby head version from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Test only supported versions: https://endoflife.date/ruby
-        ruby-version: [ '3.0', '3.1', '3.2', '3.3', head, jruby, jruby-head, truffleruby, truffleruby-head ]
+        ruby-version: [ '3.0', '3.1', '3.2', '3.3', jruby, truffleruby ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Remove Ruby head versions from CI since they are not stable yet.